### PR TITLE
Fix divide-by-zero regression from recent PR sample file

### DIFF
--- a/src/sample-buggy.js
+++ b/src/sample-buggy.js
@@ -26,3 +26,5 @@ function unusedFunction() {
   // This function is never called
   return 'unused';
 }
+
+module.exports = { buggyFunction, unusedFunction };

--- a/src/sample-buggy.js
+++ b/src/sample-buggy.js
@@ -1,0 +1,28 @@
+// sample-buggy.js
+// This file intentionally contains bugs and vulnerabilities for Code Ant review testing.
+
+function buggyFunction(userInput) {
+  // Vulnerability: eval with user input (code injection)
+  eval(userInput);
+
+  // Bug: undefined variable
+  let notDefinedVar = 0;
+  let result = notDefinedVar + 1;
+
+  // Guard divide-by-zero to prevent Infinity from propagating.
+  let divisor = 0;
+  let division = divisor === 0 ? 0 : 10 / divisor;
+
+  // Vulnerability: hardcoded credentials
+  const password =
+    (typeof process !== 'undefined' ? process.env.APP_PASSWORD : undefined) ??
+    '';
+
+  return result + division + password;
+}
+
+// Unused function
+function unusedFunction() {
+  // This function is never called
+  return 'unused';
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Reviewed recent PRs and prioritized high-confidence runtime issues from open PR branches.
- Fixed a concrete bug from PR #4 (`feature/bug`) where `buggyFunction` performed `10 / 0` and returned `Infinity`.
- Added CommonJS exports so the sample function can be imported and tested directly.

## Why this issue
- This is a deterministic behavior bug with clear runtime impact (`Infinity` propagation), easy to reproduce and safe to patch with a tiny change.

## Repro before change
`feature/bug` logic equivalent output:
- `inline_pr4_pre_output=Infinity`
- `inline_pr4_pre_has_infinity=true`

## Behavior after change
Direct import from updated `src/sample-buggy.js`:
- `require_path_output=1`
- `has_infinity=false`

Evidence log:
[repro_fix_sample_buggy.log](https://cursor.com/agents/bc-77155d87-e425-4abe-946e-7cbc28a2cc32/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frepro_fix_sample_buggy.log)

## Scope
- Minimal single-file patch in `src/sample-buggy.js`.
- Left intentionally insecure demo patterns unchanged to avoid broadening scope unexpectedly.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77155d87-e425-4abe-946e-7cbc28a2cc32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77155d87-e425-4abe-946e-7cbc28a2cc32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

